### PR TITLE
fix the bug when OpInput is empty for initiate_batch_fetch_op_2

### DIFF
--- a/src/array/operations.rs
+++ b/src/array/operations.rs
@@ -446,6 +446,9 @@ impl<'a, T: Dist> OpInput<'a, T> for &'a [T] {
     fn as_op_input(self) -> (Vec<OpInputEnum<'a, T>>, usize) {
         let len = self.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
         let num = if len < 1000 {
             1
         } else {
@@ -500,6 +503,9 @@ impl<'a, T: Dist> OpInput<'a, T> for &'a mut [T] {
     fn as_op_input(self) -> (Vec<OpInputEnum<'a, T>>, usize) {
         let len = self.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
 
         let num = if len < 1000 {
             1
@@ -573,6 +579,9 @@ impl<'a, T: Dist> OpInput<'a, T> for Vec<T> {
     //#[tracing::instrument(skip_all)]
     fn as_op_input(self) -> (Vec<OpInputEnum<'a, T>>, usize) {
         let len = self.len();
+        if len == 0 {
+            return (vec![], len);
+        }
         let num = if len < 1000 {
             1
         } else {
@@ -692,6 +701,9 @@ impl<'a, T: Dist> OpInput<'a, T> for &'a LocalLockLocalData<'_, T> {
     fn as_op_input(self) -> (Vec<OpInputEnum<'a, T>>, usize) {
         let len = self.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
         let my_pe = self.array.my_pe();
         if let Some(_start_index) = self.array.array.inner.start_index_for_pe(my_pe) {
             let num = if len < 1000 {
@@ -732,6 +744,10 @@ impl<'a, T: Dist> OpInput<'a, T> for &'a GlobalLockLocalData<'_, T> {
     fn as_op_input(self) -> (Vec<OpInputEnum<'a, T>>, usize) {
         let len = self.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
+
         let my_pe = self.array.my_pe();
         if let Some(_start_index) = self.array.array.inner.start_index_for_pe(my_pe) {
             let num = if len < 1000 {
@@ -807,6 +823,9 @@ impl<'a, T: Dist + ElementOps> OpInput<'a, T> for &GenericAtomicLocalData<T> {
         let local_data = self.clone();
         let len = local_data.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
         let my_pe = self.array.my_pe();
         if let Some(_start_index) = self.array.array.inner.start_index_for_pe(my_pe) {
             let num = if len < 1000 {
@@ -854,6 +873,9 @@ impl<'a, T: Dist + ElementOps> OpInput<'a, T> for &NativeAtomicLocalData<T> {
         let local_data = self.clone();
         let len = local_data.len();
         let mut iters = vec![];
+        if len == 0 {
+            return (iters, len);
+        }
         let my_pe = self.array.my_pe();
         if let Some(_start_index) = self.array.array.inner.start_index_for_pe(my_pe) {
             let num = if len < 1000 {

--- a/src/array/unsafe/operations.rs
+++ b/src/array/unsafe/operations.rs
@@ -271,8 +271,8 @@ impl<T: AmDist + Dist + 'static> UnsafeArray<T> {
                 )
             } else {
                 //no vals no indices
-                panic!("should not be here");
-                // Box::pin(async { Vec::new() })
+                //panic!("should not be here");
+                 Box::pin(async { Vec::new() })
             };
         Box::pin(async move {
             let mut results = Vec::with_capacity(std::cmp::max(i_len, v_len));


### PR DESCRIPTION
When the input for batch_load(...) is empty (0 elements), the runtime will panic. This can be fixed by adding a length check in Opinput::as_op_input(...). (vec![], 0) should be returned if self has 0 elements.