### PR TITLE
fix: clippy and test improvements for `impl` crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,14 +11,46 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
-    - name: UpdateRust
+    - name: Update Rust
       run: rustup update stable
     - name: Build
-      run: rustup -V && cargo build --verbose 
-    # - name: Run tests
-    #  run: cargo test --verbose
+      run: rustup -V && cargo build --verbose
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Rust
+        run: rustup update stable
+      - name: Build
+        run: rustup -V && cargo build --verbose
+      - name: Run tests
+        run: |
+          cd impl
+          cargo test --verbose
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Cargo Audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run Cargo Audit
+        run: cargo audit
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Rust
+        run: rustup update stable
+      - name: impl clippy
+        run: |
+          cd impl
+          cargo clippy --all-features --tests -- -D warnings

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -22,3 +22,6 @@ quote = "1.0.21"
 syn = { version = "2.0.17", features = ["full","extra-traits","fold","visit-mut",] }
 async-trait = "0.1.58"
 futures = "0.3.25"
+
+[dev-dependencies]
+lamellar = "0.7" # Don't depend on the latest or publishing will fail

--- a/impl/src/am_data.rs
+++ b/impl/src/am_data.rs
@@ -9,7 +9,7 @@ use quote::{quote, ToTokens};
 use syn::parse_macro_input;
 use syn::punctuated::Punctuated;
 
-fn check_attrs(attrs: &Vec<syn::Attribute>) -> (bool, bool, Vec<syn::Attribute>) {
+fn check_attrs(attrs: &[syn::Attribute]) -> (bool, bool, Vec<syn::Attribute>) {
     let mut static_field = false;
     let attrs = attrs
         .iter()
@@ -167,7 +167,7 @@ fn process_fields(
             }
         } else if !t.contains("serde::Serialize")
             && !t.contains("serde::Deserialize")
-            && t.trim().len() > 0
+            && !t.trim().is_empty()
         {
             let temp = quote::format_ident!("{}", t.trim());
             trait_strs
@@ -262,7 +262,7 @@ pub(crate) fn derive_am_data(
             &traits,
             &attrs,
             &vis,
-            &name,
+            name,
             &full_fields,
             &full_ser,
             &full_des,
@@ -276,7 +276,7 @@ pub(crate) fn derive_am_data(
                 &group_traits,
                 &group_attrs,
                 &vis,
-                &name,
+                name,
                 &fields,
                 &static_fields,
                 &lamellar,

--- a/impl/src/field_info.rs
+++ b/impl/src/field_info.rs
@@ -24,7 +24,7 @@ impl FieldInfo {
                     ser.extend(self.ser_path(field, *darc_iter, false));
                 }
                 syn::Type::Tuple(ty) => {
-                    ser.extend(self.ser_tuple(field, &ty, false));
+                    ser.extend(self.ser_tuple(field, ty, false));
                 }
                 _ => {
                     abort!(
@@ -46,7 +46,7 @@ impl FieldInfo {
                     ser.extend(self.ser_path(field, *darc_iter, true));
                 }
                 syn::Type::Tuple(ty) => {
-                    ser.extend(self.ser_tuple(field, &ty, true));
+                    ser.extend(self.ser_tuple(field, ty, true));
                 }
                 _ => {
                     abort!(
@@ -131,7 +131,7 @@ impl FieldInfo {
                     des.extend(self.des_path(field, *darc_iter, false));
                 }
                 syn::Type::Tuple(ty) => {
-                    des.extend(self.des_tuple(field, &ty, false));
+                    des.extend(self.des_tuple(field, ty, false));
                 }
                 _ => {
                     abort!(
@@ -153,7 +153,7 @@ impl FieldInfo {
                     des.extend(self.des_path(field, *darc_iter, true));
                 }
                 syn::Type::Tuple(ty) => {
-                    des.extend(self.des_tuple(field, &ty, true));
+                    des.extend(self.des_tuple(field, ty, true));
                 }
                 _ => {
                     abort!(

--- a/impl/src/gen_am_group.rs
+++ b/impl/src/gen_am_group.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use crate::field_info::FieldInfo;
 use crate::gen_am::*;
 use crate::replace::{LamellarDSLReplace, ReplaceSelf};
@@ -12,21 +14,21 @@ fn impl_am_group_remote_lamellar_active_message_trait(
     generics: &syn::Generics,
     am_group_am_name: &syn::Ident,
     am_group_body: &proc_macro2::TokenStream,
-    ret_contatiner: &proc_macro2::TokenStream,
+    ret_container: &proc_macro2::TokenStream,
     ret_push: &proc_macro2::TokenStream,
     ret_stmt: &proc_macro2::TokenStream,
     lamellar: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     // let trace_name = quote! {stringify!(#am_group_am_name)};
-    // println!("ret_contatiner: {}", ret_contatiner.to_string());
+    // println!("ret_container: {}", ret_container.to_string());
     // println!("ret_push: {}", ret_push.to_string());
     // println!("ret_stmt: {}", ret_stmt.to_string());
     quote! {
         impl #impl_generics #lamellar::active_messaging::LamellarActiveMessage for #am_group_am_name #ty_generics #where_clause {
             fn exec(self: std::sync::Arc<Self>,__lamellar_current_pe: usize,__lamellar_num_pes: usize, __local: bool, __lamellar_world: std::sync::Arc<#lamellar::LamellarTeam>, __lamellar_team: std::sync::Arc<#lamellar::LamellarTeam>) -> std::pin::Pin<Box<dyn std::future::Future<Output=#lamellar::active_messaging::LamellarReturn> + Send >>{
                 Box::pin( async move {
-                    #ret_contatiner
+                    #ret_container
                     for i in 0..self.len(){
                         let _e = { #am_group_body };
                         #ret_push
@@ -189,7 +191,7 @@ fn impl_am_group_remote(
     am_group_am_name: &syn::Ident,
     am_group_body: &proc_macro2::TokenStream,
     ret_type: &proc_macro2::TokenStream,
-    ret_contatiner: &proc_macro2::TokenStream,
+    ret_container: &proc_macro2::TokenStream,
     ret_push: &proc_macro2::TokenStream,
     ret_stmt: &proc_macro2::TokenStream,
     lamellar: &proc_macro2::TokenStream,
@@ -198,7 +200,7 @@ fn impl_am_group_remote(
         generics,
         am_group_am_name,
         am_group_body,
-        ret_contatiner,
+        ret_container,
         ret_push,
         ret_stmt,
         lamellar,
@@ -440,9 +442,9 @@ pub(crate) fn generate_am_group(
         }
     };
 
-    let am_group_remote_body = gen_am_group_remote_body2(&orig_name, &input);
+    let am_group_remote_body = gen_am_group_remote_body2(&orig_name, input);
 
-    let (ret_contatiner, ret_push, ret_stmt) =
+    let (ret_container, ret_push, ret_stmt) =
         gen_am_group_return_stmt(&am_type, &am_group_return_name, lamellar, false);
 
     let am_group_remote = impl_am_group_remote(
@@ -450,18 +452,18 @@ pub(crate) fn generate_am_group(
         &am_group_am_name,
         &am_group_remote_body,
         &ret_type,
-        &ret_contatiner,
+        &ret_container,
         &ret_push,
         &ret_stmt,
-        &lamellar,
+        lamellar,
     );
 
     let am_group_return = impl_return_struct(
         &generics,
-        &am_data_header,
+        am_data_header,
         &am_group_return_name,
         &ret_type,
-        &lamellar,
+        lamellar,
         false,
         local,
     );
@@ -473,7 +475,7 @@ pub(crate) fn generate_am_group(
         &am_group_am_name,
         &am_group_user_name,
         &inner_ret_type,
-        &lamellar,
+        lamellar,
     );
 
     let mut am_user_generics = generics.clone();
@@ -592,7 +594,7 @@ fn create_am_group_remote(
         }
     });
 
-    let my_len = if fields.names().len() > 0 {
+    let my_len = if !fields.names().is_empty() {
         let f = &fields.names()[0];
         quote! {
             self.#f.len()
@@ -653,7 +655,7 @@ pub(crate) fn create_am_group_structs(
     let am_group_user_struct = generate_am_group_user_struct(
         generics,
         vis,
-        &get_am_group_user_name(&name),
+        &get_am_group_user_name(name),
         &get_am_group_name(&format_ident!("{}", name)),
     );
 

--- a/impl/src/parse.rs
+++ b/impl/src/parse.rs
@@ -84,23 +84,24 @@ impl Parse for ReductionArgs {
             })
         }
         Ok(ReductionArgs {
-            name: name,
-            closure: closure,
-            tys: tys,
+            name,
+            closure,
+            tys,
         })
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum VecArgs {
-    List(Vec<syn::Expr>),
-    Size((syn::Expr, syn::Expr)),
+    List(Vec<Expr>),
+    Size((Expr, Expr)),
 }
 
 impl Parse for VecArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        let first: syn::Expr = if let Ok(first) = input.parse::<syn::Lit>() {
-            syn::Expr::Lit(syn::ExprLit {
+        let first: Expr = if let Ok(first) = input.parse::<syn::Lit>() {
+            Expr::Lit(syn::ExprLit {
                 attrs: vec![],
                 lit: first,
             })
@@ -112,7 +113,7 @@ impl Parse for VecArgs {
             while !input.is_empty() {
                 input.parse::<Token![,]>()?;
                 let elem = if let Ok(elem) = input.parse::<syn::Lit>() {
-                    syn::Expr::Lit(syn::ExprLit {
+                    Expr::Lit(syn::ExprLit {
                         attrs: vec![],
                         lit: elem,
                     })
@@ -125,7 +126,7 @@ impl Parse for VecArgs {
         } else if input.peek(Token![;]) {
             input.parse::<Token![;]>()?;
             let second = if let Ok(second) = input.parse::<syn::Lit>() {
-                syn::Expr::Lit(syn::ExprLit {
+                Expr::Lit(syn::ExprLit {
                     attrs: vec![],
                     lit: second,
                 })


### PR DESCRIPTION
I'm trying an easier approach to getting Clippy to work by just looking at the `impl` macro crate.

I'm having a trouble with some of the documentation tests, such as:

```rust
use lamellar::active_messaging::prelude::*;
use lamellar::darc::prelude::*;
use std::sync::Arc;
use std::sync::atomic::AtomicUsize;

#[AmData(Debug, Clone)]
struct ExampleAm {
   #[AmData(static)]
   cnt: Darc<AtomicUsize>,
}
```

Error:
```console
 #[AmData(static)]
  |       ^^^^^^ not a non-macro attribute
```

Am I missing something, or did I break something?